### PR TITLE
Update RxSwift to version 5.1.0

### DIFF
--- a/MGArchitecture.podspec
+++ b/MGArchitecture.podspec
@@ -8,7 +8,7 @@ s.summary = "Clean Architecture with RxSwift and MVVM"
 s.requires_arc = true
 
 # 2
-s.version = "1.2.0"
+s.version = "1.2.1"
 
 # 3
 s.license = { :type => "MIT", :file => "LICENSE" }
@@ -25,8 +25,8 @@ s.source = { :git => "https://github.com/tuan188/MGArchitecture.git",
 
 # 7
 s.framework = "UIKit"
-s.dependency 'RxSwift', '~> 5.0'
-s.dependency 'RxCocoa', '~> 5.0'
+s.dependency 'RxSwift', '~> 5.1'
+s.dependency 'RxCocoa', '~> 5.1'
 
 # 8
 s.source_files = "MGArchitecture/Sources/**/*.{swift}"
@@ -35,7 +35,7 @@ s.source_files = "MGArchitecture/Sources/**/*.{swift}"
 # s.resources = "MGArchitecture/**/*.{png,jpeg,jpg,storyboard,xib,xcassets}"
 
 # 10
-s.swift_version = "5.0"
+s.swift_version = "5.1"
 
 end
 

--- a/Podfile
+++ b/Podfile
@@ -6,8 +6,8 @@ def pods
     
     pod 'MGLoadMore', '~> 0.5'
     
-    pod 'RxSwift', '5.0'
-    pod 'RxCocoa', '5.0'
+    pod 'RxSwift', '5.1'
+    pod 'RxCocoa', '5.1'
     pod 'NSObject+Rx', '5.0'
     
     pod 'Then', '2.4'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -12,12 +12,12 @@ PODS:
     - Reusable/View (= 4.1.0)
   - Reusable/Storyboard (4.1.0)
   - Reusable/View (4.1.0)
-  - RxCocoa (5.0.0):
+  - RxCocoa (5.1.0):
     - RxRelay (~> 5)
     - RxSwift (~> 5)
-  - RxRelay (5.0.0):
+  - RxRelay (5.1.0):
     - RxSwift (~> 5)
-  - RxSwift (5.0.0)
+  - RxSwift (5.1.0)
   - Then (2.4.0)
 
 DEPENDENCIES:
@@ -25,21 +25,22 @@ DEPENDENCIES:
   - MGLoadMore (~> 0.5)
   - "NSObject+Rx (= 5.0)"
   - Reusable (= 4.1.0)
-  - RxCocoa (= 5.0)
-  - RxSwift (= 5.0)
+  - RxCocoa (= 5.1)
+  - RxSwift (= 5.1)
   - Then (= 2.4)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - MBProgressHUD
     - MGLoadMore
     - MJRefresh
     - "NSObject+Rx"
     - Reusable
+    - Then
+  trunk:
     - RxCocoa
     - RxRelay
     - RxSwift
-    - Then
 
 SPEC CHECKSUMS:
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
@@ -47,11 +48,11 @@ SPEC CHECKSUMS:
   MJRefresh: ed450d6eb9d3346a2cb033ab7eb6de090aeef437
   "NSObject+Rx": 6151a97d171f7187c4183746acc42d9451952a7b
   Reusable: 82be188f29d96dc5eff0db7b2393bcc08d2cdd5b
-  RxCocoa: fcf32050ac00d801f34a7f71d5e8e7f23026dcd8
-  RxRelay: 4f7409406a51a55cd88483f21ed898c234d60f18
-  RxSwift: 8b0671caa829a763bbce7271095859121cbd895f
+  RxCocoa: 13d2a4d7546a34b8ececae8c281e4ea1dbb94f2b
+  RxRelay: a168bd6caf712d00c676ac344e9295afc93b418e
+  RxSwift: ad5874f24bb0dbffd1e9bb8443604e3578796c7a
   Then: 71866660c7af35a7343831f7668e7cd2b62ee0f2
 
-PODFILE CHECKSUM: fbd4e7880909a58f9e2f3e7c73e1f0d0939e550e
+PODFILE CHECKSUM: 957c13fa20c0a74fd40d7172d43d0ae15269530e
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4


### PR DESCRIPTION
RxSwift has a new release, this release removes UIWebView Reactive Extensions due to [Apple's hard deprecation, starting April 2020 ](https://developer.apple.com/news/?id=12232019b)
which also allows RxSwift to be used in Catalyst apps. [#2062](https://github.com/ReactiveX/RxSwift/blob/5.1.0/CHANGELOG.md)

https://github.com/ReactiveX/RxSwift/releases/tag/5.1.0

Please update Cocoapod.